### PR TITLE
Change XPath custom prefixes to avoid conflicts

### DIFF
--- a/carddav_backend.php
+++ b/carddav_backend.php
@@ -445,7 +445,7 @@ EOF
 
 	$xml = self::$helper->checkAndParseXML($reply);
 	if($xml !== false) {
-		$xpresult = $xml->xpath('//D:supported-report/D:report/D:sync-collection');
+		$xpresult = $xml->xpath('//RCMCD:supported-report/RCMCD:report/RCMCD:sync-collection');
 		if(count($xpresult) > 0) {
 			$records = $this->list_records_sync_collection();
 		}
@@ -574,7 +574,7 @@ EOF
 			}
 		}
 
-		list($new_sync_token) = $xml->xpath('//D:sync-token');
+		list($new_sync_token) = $xml->xpath('//RCMCD:sync-token');
 
 		$records = $this->addvcards($xml);
 
@@ -590,7 +590,7 @@ EOF
 			carddav::update_abook($this->config['abookid'], array('sync_token' => "$new_sync_token"));
 
 			// if we got a truncated result set continue sync
-			$xpresult = $xml->xpath('//D:response[contains(child::D:status, " 507 Insufficient Storage")]');
+			$xpresult = $xml->xpath('//RCMCD:response[contains(child::RCMCD:status, " 507 Insufficient Storage")]');
 			if(count($xpresult) > 0) {
 				$sync_token = "$new_sync_token";
 				continue;
@@ -703,14 +703,14 @@ EOF
 	$xml = self::$helper->checkAndParseXML($reply);
 	if($xml === false) return -1;
 
-	$xpresult = $xml->xpath('//D:response[descendant::C:address-data]');
+	$xpresult = $xml->xpath('//RCMCD:response[descendant::RCMCC:address-data]');
 
 	$numcards = 0;
 	foreach ($xpresult as $vcard) {
 		self::$helper->registerNamespaces($vcard);
-		list($href) = $vcard->xpath('child::D:href');
-		list($etag) = $vcard->xpath('descendant::D:getetag');
-		list($vcf)  = $vcard->xpath('descendant::C:address-data');
+		list($href) = $vcard->xpath('child::RCMCD:href');
+		list($etag) = $vcard->xpath('descendant::RCMCD:getetag');
+		list($vcf)  = $vcard->xpath('descendant::RCMCC:address-data');
 
 		// determine database ID of existing cards by checking the cache
 		$dbid = 0;
@@ -786,14 +786,14 @@ EOF
 	private function addvcards($xml)
 	{{{
 	$urls = array();
-	$xpresult = $xml->xpath('//D:response[starts-with(translate(child::D:propstat/D:status, "ABCDEFGHJIKLMNOPQRSTUVWXYZ", "abcdefghjiklmnopqrstuvwxyz"), "http/1.1 200 ") and child::D:propstat/D:prop/D:getetag]');
+	$xpresult = $xml->xpath('//RCMCD:response[starts-with(translate(child::RCMCD:propstat/RCMCD:status, "ABCDEFGHJIKLMNOPQRSTUVWXYZ", "abcdefghjiklmnopqrstuvwxyz"), "http/1.1 200 ") and child::RCMCD:propstat/RCMCD:prop/RCMCD:getetag]');
 	foreach ($xpresult as $r) {
 		self::$helper->registerNamespaces($r);
 
-		list($href) = $r->xpath('child::D:href');
+		list($href) = $r->xpath('child::RCMCD:href');
 		if(preg_match('/\/$/', $href)) continue;
 
-		list($etag) = $r->xpath('descendant::D:getetag');
+		list($etag) = $r->xpath('descendant::RCMCD:getetag');
 
 		$ret = self::checkcache($this->existing_card_cache,"$href","$etag");
 		$retgrp = self::checkcache($this->existing_grpcard_cache,"$href","$etag");
@@ -836,14 +836,14 @@ EOF
 	/** delete cards reported deleted by the server */
 	private function delete_synccoll($xml)
 	{{{
-	$xpresult = $xml->xpath('//D:response[contains(child::D:status, " 404 Not Found")]');
+	$xpresult = $xml->xpath('//RCMCD:response[contains(child::RCMCD:status, " 404 Not Found")]');
 	$del_contacts = array();
 	$del_groups = array();
 
 	foreach ($xpresult as $r) {
 		self::$helper->registerNamespaces($r);
 
-		list($href) = $r->xpath('child::D:href');
+		list($href) = $r->xpath('child::RCMCD:href');
 		if(preg_match('/\/$/', $href)) continue;
 
 		if(isset($this->existing_card_cache["$href"])) {

--- a/carddav_common.php
+++ b/carddav_common.php
@@ -119,8 +119,9 @@ class carddav_common
 	}
 
 	public function registerNamespaces($xml) {
-		$xml->registerXPathNamespace('C', self::NSCARDDAV);
-		$xml->registerXPathNamespace('D', self::NSDAV);
+		// Use slightly complex prefixes to avoid conflicts
+		$xml->registerXPathNamespace('RCMCC', self::NSCARDDAV);
+		$xml->registerXPathNamespace('RCMCD', self::NSDAV);
 	}
 
 	// HTTP helpers

--- a/carddav_discovery.php
+++ b/carddav_discovery.php
@@ -133,12 +133,12 @@ EOF
 	$aBooks = array();
 
 	// (1) check if we found addressbooks at the URL
-	$xpresult = $xml->xpath('//D:response[descendant::D:resourcetype/C:addressbook]');
+	$xpresult = $xml->xpath('//RCMCD:response[descendant::RCMCD:resourcetype/RCMCC:addressbook]');
 	foreach($xpresult as $ab) {
 		self::$helper->registerNamespaces($ab);
 		$aBook = array();
-		list($aBook['href']) = $ab->xpath('child::D:href');
-		list($aBook['name']) = $ab->xpath('descendant::D:displayname');
+		list($aBook['href']) = $ab->xpath('child::RCMCD:href');
+		list($aBook['name']) = $ab->xpath('descendant::RCMCD:displayname');
 		$aBook['href'] = (string) $aBook['href'];
 		$aBook['name'] = (string) $aBook['name'];
 
@@ -153,10 +153,10 @@ EOF
 	if(count($aBooks) > 0) return $aBooks;
 
 	// (2) see if the server told us the addressbook home location
-	list($abookhome) = $xml->xpath('//C:addressbook-home-set/D:href');
+	list($abookhome) = $xml->xpath('//RCMCC:addressbook-home-set/RCMCD:href');
 	self::$helper->debug("addressbook home: $abookhome");
 	// (3) see if we got a principal URL
-	list($princurl) = $xml->xpath('//D:current-user-principal/D:href');
+	list($princurl) = $xml->xpath('//RCMCD:current-user-principal/RCMCD:href');
 	self::$helper->debug("principal URL: $princurl");
 
 	foreach(array($abookhome,$princurl) as $url) {


### PR DESCRIPTION
If any of the prefixes defined in `carddav_common::registerNamespaces()` is
already used in the XML document generated by the CardDAV server, SimpleXML
will ignore it if it doesn't identify the same namespace, so XPath
queries will not use it as expected. More info can be found on the following StackOverflow question: http://stackoverflow.com/questions/16668780/how-to-solve-a-naming-conflict-when-specifying-a-custom-prefix-using-xpath .

In fact, DAViCal uses 'C' as the prefix for the CalDAV namespace, but the module tries to use it for CardDAV, so they conflict and most XPath queries just don't work.

This PR changes XPath prefixes to other ones that aren't likely to be
already used.

This change is really necessary to make the module work on certain CardDAV servers.
