### PR TITLE
fix bug where in some cases config.inc.php doesn't get loaded

### DIFF
--- a/carddav_common.php
+++ b/carddav_common.php
@@ -322,8 +322,8 @@ class carddav_common
 
 	$rcmail = rcmail::get_instance();
 	$prefs = array();
-	if (file_exists("config.inc.php"))
-		require("config.inc.php");
+	if (file_exists(dirname(__FILE__)."/config.inc.php"))
+		require(dirname(__FILE__)."/config.inc.php");
 	self::$admin_settings = $prefs;
 
 	if(is_array($prefs['_GLOBAL'])) {


### PR DESCRIPTION
config.inc.php doesn't get loaded if working dir is not the plugin dir, or include_path doesn't contain '.'
