### PR TITLE
Use utf8 charset for MySQL tables

### DIFF
--- a/dbinit/mysql.sql
+++ b/dbinit/mysql.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS carddav_addressbooks (
 
 	PRIMARY KEY(id),
 	FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE ON UPDATE CASCADE
-) /*!40000 ENGINE=INNODB */;
+) CHARACTER SET utf8 COLLATE utf8_unicode_ci /*!40000 ENGINE=INNODB */;
 
 CREATE TABLE IF NOT EXISTS carddav_contacts (
 	id INT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS carddav_contacts (
 	UNIQUE INDEX(uri,abook_id),
 	UNIQUE INDEX(cuid,abook_id),
 	FOREIGN KEY (abook_id) REFERENCES carddav_addressbooks(id) ON DELETE CASCADE ON UPDATE CASCADE
-) /*!40000 ENGINE=INNODB */;
+) CHARACTER SET utf8 COLLATE utf8_unicode_ci /*!40000 ENGINE=INNODB */;
 
 CREATE TABLE IF NOT EXISTS carddav_xsubtypes (
 	id INT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS carddav_xsubtypes (
 	PRIMARY KEY(id),
 	UNIQUE INDEX(typename,subtype,abook_id),
 	FOREIGN KEY (abook_id) REFERENCES carddav_addressbooks(id) ON DELETE CASCADE ON UPDATE CASCADE
-) /*!40000 ENGINE=INNODB */;
+) CHARACTER SET utf8 COLLATE utf8_unicode_ci /*!40000 ENGINE=INNODB */;
 
 CREATE TABLE IF NOT EXISTS carddav_groups (
 	id INT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -62,7 +62,7 @@ CREATE TABLE IF NOT EXISTS carddav_groups (
 	UNIQUE(cuid,abook_id),
 
 	FOREIGN KEY (abook_id) REFERENCES carddav_addressbooks(id) ON DELETE CASCADE ON UPDATE CASCADE
-) /*!40000 ENGINE=INNODB */;
+) CHARACTER SET utf8 COLLATE utf8_unicode_ci /*!40000 ENGINE=INNODB */;
 
 CREATE TABLE IF NOT EXISTS carddav_group_user (
 	group_id   INT UNSIGNED NOT NULL,
@@ -71,5 +71,5 @@ CREATE TABLE IF NOT EXISTS carddav_group_user (
 	PRIMARY KEY(group_id,contact_id),
 	FOREIGN KEY(group_id) REFERENCES carddav_groups(id) ON DELETE CASCADE ON UPDATE CASCADE,
 	FOREIGN KEY(contact_id) REFERENCES carddav_contacts(id) ON DELETE CASCADE ON UPDATE CASCADE
-) /*!40000 ENGINE=INNODB */;
+) CHARACTER SET utf8 COLLATE utf8_unicode_ci /*!40000 ENGINE=INNODB */;
 


### PR DESCRIPTION
See [FS#91](http://bugs.crash-override.net/index.php?do=details&task_id=91).

If no character set/collation is specified when creating a table, the database default is used. MySQL uses the latin1 charset with the latin1_swedish_ci collation by default -- this means that in the worst case (if the administrator didn't choose a more sane default charset), characters not contained in the latin1 charset will be garbled in the address books. Explicitly choosing an Unicode charset and collation makes sure that these characters are stored correctly in all cases.

I chose the utf8_unicode_ci collation because even if it is slower than the utf8_general_ci collation, it is more accurate (which seems appropriate for an address book). The [MySQL manual](http://dev.mysql.com/doc/refman/5.6/en/charset-unicode-sets.html) has more information.
