### PR TITLE
Reset count on searching

### DIFF
--- a/carddav_backend.php
+++ b/carddav_backend.php
@@ -204,6 +204,7 @@ class carddav_backend extends rcube_addressbook
 	public function set_search_set($filter)
 	{{{
 	$this->filter = $filter;
+	$this->total_cards = -1;
 	}}}
 
 	/**
@@ -1820,6 +1821,7 @@ EOF
 	public function set_group($gid)
 	{{{
 	$this->group_id = $gid;
+	$this->total_cards = -1;
 	$this->filter = "EXISTS(SELECT * FROM ".get_table_name("carddav_group_user")."
 		WHERE group_id = '{$gid}' AND contact_id = ".get_table_name("carddav_contacts").".id)";
 	}}}


### PR DESCRIPTION
When using the `search` method on a CardDAV backed, consecutive searches reuse the first results count.

This produces some undesired behaviours for some operations. For instance, when importing a .vcf on a CardDAV address book, most of the contacts are skipped if any of them was already present.

This PR just resets the `total_count` attribute when setting a new filter or a new group on the backend.
