### PR TITLE
Fix set_group when no group is specified

### DIFF
--- a/carddav_backend.php
+++ b/carddav_backend.php
@@ -1832,8 +1832,12 @@ EOF
 	{{{
 	$this->group_id = $gid;
 	$this->total_cards = -1;
-	$this->filter = "EXISTS(SELECT * FROM ".get_table_name("carddav_group_user")."
-		WHERE group_id = '{$gid}' AND contact_id = ".get_table_name("carddav_contacts").".id)";
+	if ($gid) {
+		$this->filter = "EXISTS(SELECT * FROM ".get_table_name("carddav_group_user")."
+			WHERE group_id = '{$gid}' AND contact_id = ".get_table_name("carddav_contacts").".id)";
+	} else {
+		$this->filter = '';
+	}
 	}}}
 
 	/**


### PR DESCRIPTION
Some pages that list contacts (e.g. when composing a message) issue a `set_group(0)` on the addressbook object.

That means not restricting the search to a group at all. However, the plugin tries to search for contacts belonging to a group with id = 0. Generated SQL sentence follows:

<pre>
[22-Jan-2014 12:03:00 +0100]: [15] SELECT id,name,firstname,surname,email FROM carddav_contacts
WHERE abook_id='2' 
AND (EXISTS(
SELECT * FROM carddav_group_user WHERE group_id = '0' AND contact_id = carddav_contacts.id
))
ORDER BY (CASE WHEN showas='COMPANY' THEN organization ELSE surname END) ASC LIMIT 50;
</pre>


You can see how Roundcube handles this on LDAP addressbooks (https://github.com/roundcube/roundcubemail/blob/master/program/lib/Roundcube/rcube_ldap.php#L1567).

Without this patch, the Compose window will show no contacts when clicking on a CardDAV addressbook.
