### PR TITLE
Provide an option to use only the local part of the email address as username

### DIFF
--- a/carddav_common.php
+++ b/carddav_common.php
@@ -150,13 +150,19 @@ class carddav_common
 	// determine calling function for debug output
 	$caller=self::getCaller();
 
+	$local = $rcmail->user->get_username('local');
+
 	// Substitute Placeholders
 	if($username == '%u')
 		$username = $_SESSION['username'];
+	if($username == '%l')
+		$username = $local;
 	if($password == '%p')
 		$password = $rcmail->decrypt($_SESSION['password']);
 	$baseurl = str_replace("%u", $username, $carddav['url']);
 	$url = str_replace("%u", $username, $url);
+	$baseurl = str_replace("%l", $local, $carddav['url']);
+	$url = str_replace("%l", $local, $url);
 
 	// if $url is relative, prepend the base url
 	$url = self::concaturl($baseurl, $url);

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -70,7 +70,10 @@ $prefs['<Presetname>'] = array(
 //               if carddav_name_only is true (see below).
 //
 // username:     CardDAV username to access the addressbook. Set this setting
-//               to '%u' to use the roundcube username.
+//               to '%u' to use the roundcube username. In case one uses an
+//               email address as username there is the additional option to
+//               choose '%l', which will only use the local part of the
+//               username.
 //
 // password:     CardDAV password to access the addressbook. Set this setting
 //               to '%p' to use the roundcube password. The password will not
@@ -83,6 +86,7 @@ $prefs['<Presetname>'] = array(
 //               addressbook, the server will be queried for the available
 //               addressbooks and all of them will be added. You can use %u
 //               within the URL as a placeholder for the CardDAV username.
+//               '%l' works the same way as it does for the username field.
 //
 // The following parameters are OPTIONAL and need to be specified only if the default
 // value is not acceptable.


### PR DESCRIPTION
In case one uses the email address as username it is sometimes beneficial
to only use the local part of the email address as CardDAV username.
