### PR TITLE
Fix group membership removal

### DIFF
--- a/carddav_backend.php
+++ b/carddav_backend.php
@@ -1797,7 +1797,7 @@ EOF
 	if(!$this->dbstore_group($etag,$group['uri'],$vcfstr,$group,$group_id))
 		return false;
 
-	self::delete_dbrecord($ids,'group_user','contact_id');
+	self::delete_dbrecord($ids,'group_user','contact_id', array('group_id' => $group_id));
 	return $deleted;
 	}}}
 
@@ -1978,7 +1978,7 @@ EOF
 	return $ret;
 	}}}
 
-	public static function delete_dbrecord($ids, $table='contacts', $idfield='id')
+	public static function delete_dbrecord($ids, $table='contacts', $idfield='id', $other_conditions = array())
 	{{{
 	$dbh = rcmail::get_instance()->db;
 
@@ -1992,9 +1992,14 @@ EOF
 	}
 
 	$idfield = $dbh->quoteIdentifier($idfield);
-	$sql_result = $dbh->query("DELETE FROM " .
-		get_table_name("carddav_$table") .
-		" WHERE $idfield $dspec" );
+	$sql = "DELETE FROM " . get_table_name("carddav_$table") . " WHERE $idfield $dspec";
+
+	// Append additional conditions
+	foreach ($other_conditions as $field => $value) {
+		$sql .= ' AND ' . $dbh->quoteIdentifier($field) . ' = ' . $dbh->quote($value);
+	}
+
+	$sql_result = $dbh->query($sql);
 	return $dbh->affected_rows($sql_result);
 	}}}
 


### PR DESCRIPTION
Removing a contact from a single group causes it to be removed from every group the contact was in, at least on the database. VCards work as expected.

**Steps to reproduce:**
1. Create 2 or more groups (example: _Group1_, _Group2_, _Group3_)
2. Create a new contact (_Contact1_).
3. Open _Contact1_,  access the Groups tab and add it to _Group1_, _Group2_ and _Group3_
4. Open any other contact/group and then open _Contact1_ again. Make sure the Groups tab shows it is associated to the three groups
5. Remove _Contact1_ it from _Group1_ (uncheck)
6. Open any other contact/group and then open _Contact1_ again
7. Now the contact isn't a member of neither _Group2_ nor _Group3_

**Description of the solution provided by this PR:**

When removing a contact from a group, the CardDAV backend generates an SQL sentence that removes it from every group. The condition to remove it just from a given group is missing.

This PR adds an `$other_conditions` argument to the `delete_dbrecord()` method, which is used by `remove_from_group()` to specify which group the contact has to be removed from.
