### PR TITLE
issue 35 - fix %u replacement in baseurl

### DIFF
--- a/carddav_common.php
+++ b/carddav_common.php
@@ -161,7 +161,7 @@ class carddav_common
 		$password = $rcmail->decrypt($_SESSION['password']);
 	$baseurl = str_replace("%u", $username, $carddav['url']);
 	$url = str_replace("%u", $username, $url);
-	$baseurl = str_replace("%l", $local, $carddav['url']);
+	$baseurl = str_replace("%l", $local, $baseurl);
 	$url = str_replace("%l", $local, $url);
 
 	// if $url is relative, prepend the base url


### PR DESCRIPTION
the string replace for %l is using $carddav['url'], inadvertently overwriting the string replace for %u on line 162.
