### PR TITLE
added password encryption with roundcube des_key

### DIFF
--- a/carddav_common.php
+++ b/carddav_common.php
@@ -284,6 +284,15 @@ class carddav_common
 		return '{ENCRYPTED}'.$crypted;
 	}
 
+	if(strcasecmp(self::$pwstore_scheme, 'des_key')===0) {
+
+		// encrypted with global des_key
+		$rcmail = rcmail::get_instance();
+		$crypted = $rcmail->encrypt($clear);
+
+		return '{DES_KEY}'.$crypted;
+	}
+
 	// default: base64-coded password
 	return '{BASE64}'.base64_encode($clear);
 	}}}
@@ -292,6 +301,9 @@ class carddav_common
 	{{{
 	if(strpos($crypt, '{ENCRYPTED}') === 0)
 		return 'encrypted';
+
+	if(strpos($crypt, '{DES_KEY}') === 0)
+		return 'des_key';
 
 	if(strpos($crypt, '{BASE64}') === 0)
 		return 'base64';
@@ -315,6 +327,13 @@ class carddav_common
 		$deskey_backup = $rcmail->config->set('carddav_des_key', '');
 
 		return $clear;
+	}
+
+	if(strpos($crypt, '{DES_KEY}') === 0) {
+		$crypt = substr($crypt, strlen('{DES_KEY}'));
+		$rcmail = rcmail::get_instance();
+
+		return $rcmail->decrypt($crypt);
 	}
 
 	if(strpos($crypt, '{BASE64}') === 0) {
@@ -342,7 +361,7 @@ class carddav_common
 
 	if(is_array($prefs['_GLOBAL'])) {
 		$scheme = $prefs['_GLOBAL']['pwstore_scheme'];
-		if(preg_match("/^(plain|base64|encrypted)$/", $scheme))
+		if(preg_match("/^(plain|base64|encrypted|des_key)$/", $scheme))
 			self::$pwstore_scheme = $scheme;
 	}
 	return $prefs;

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -24,6 +24,7 @@
 //            NOTE: if the IMAP password of the user changes, the stored
 //             CardDAV passwords cannot be decrypted anymore and the user
 //             needs to reenter them.
+// des_key: store encrypted with global des_key of roundcube
 // $prefs['_GLOBAL']['pwstore_scheme'] = 'base64';
 
 //// ** ADDRESSBOOK PRESETS


### PR DESCRIPTION
Hi there,

my first pull request ever \o/!

I thought it would be nice if we can store the password using the roundcube encryptition with the global des_key since this key is not supposed to be changed as the imap password. It might also be a good idea using this as default method.