### PR TITLE
Fix authentication issue with calendarserver

### DIFF
--- a/carddav_common.php
+++ b/carddav_common.php
@@ -192,7 +192,9 @@ class carddav_common
 					$httpful->basicAuth($username, $password);
 					$scheme = "basic";
 				}
-				carddav_backend::update_addressbook($carddav['abookid'], array("authentication_scheme"), array($scheme));
+
+				if ($scheme != "unknown")
+					carddav_backend::update_addressbook($carddav['abookid'], array("authentication_scheme"), array($scheme));
 		} else {
 			if (strtolower($scheme) == "digest"){
 				$httpful->digestAuth($username, $password);


### PR DESCRIPTION
On my calendarserver instance, some queries can be done successfully
even when not authenticated, but then return no valid data. This
results in seeing an empty addressbook.

Fix this by making sure to store the authentication method only when
it becomes known; this way, future queries will always use it even
if they were such queries that are OK even without authentication.
This makes the addressbook have valid contents.