### PR TITLE
Fixes #116 - Function array dereferencing missing in PHP 5.3.x

### DIFF
--- a/carddav_backend.php
+++ b/carddav_backend.php
@@ -1780,7 +1780,8 @@ EOF
 
 			$vcfstr = $vcf->serialize();
 
-			$save_data = $this->create_save_data_from_vcard("$vcfstr")['save_data'];
+			$save_data_arr = $this->create_save_data_from_vcard("$vcfstr");
+			$save_data = $save_data_arr['save_data'];
 
 			// complete save_data
 			$save_data['showas'] = $contact['showas'];


### PR DESCRIPTION
Fixes #116. Function array dereferencing was introduced in PHP 5.4.x.
This fix makes `carddav` again PHP 5.3.x compatible.
http://php.net/manual/en/migration54.new-features.php
