### PR TITLE
Added condition to prevent error with composer install

### DIFF
--- a/carddav_common.php
+++ b/carddav_common.php
@@ -19,7 +19,8 @@
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-require_once __DIR__ . '/vendor/autoload.php';
+if (file_exists(__DIR__ . '/vendor/autoload.php'))
+	require_once __DIR__ . '/vendor/autoload.php';
 
 \Httpful\Bootstrap::init();
 


### PR DESCRIPTION
A simple if conditions fixes the error with the "standard" plugin install (composer) recommended by the roundcube developers.