### PR TITLE
Update carddav_backend.php

### DIFF
--- a/carddav_backend.php
+++ b/carddav_backend.php
@@ -1438,7 +1438,7 @@ EOF
 			foreach($pvalue['TYPE'] as $type)
 			{
 				$type = strtolower($type);
-				if( in_array($type, $this->coltypes[$attrname]['subtypes']) )
+				if(is_array($this->coltypes[$attrname]['subtypes') && in_array($type, $this->coltypes[$attrname]['subtypes']) )
 				{
 					$fallback = $type;
 					if(!(is_array($this->fallbacktypes[$attrname])


### PR DESCRIPTION
fix php notices complaining, that in_array() expects an array as second parameter.


after installation, roundcube yelled at me, that $this->coltypes[$attrname]['subtypes'] wasn't an array.
i didn't debug it further but now this issue vanished even without this "fix"