### PR TITLE
Prevent concurrent syncs using database locks

### DIFF
--- a/carddav_backend.php
+++ b/carddav_backend.php
@@ -422,6 +422,13 @@ class carddav_backend extends rcube_addressbook
 	$dbh = rcmail::get_instance()->db;
 	$duration = time();
 
+	self::$helper->debug("begin server refresh of addressbook " . $this->id);
+
+	if (!self::$helper->acquire_lock($this->id)) {
+		self::$helper->debug("could not acquire lock for server refresh of addressbook " . $this->id);
+		return;
+	}
+
 	// determine existing local contact URIs and ETAGs
 	$contacts = self::get_dbrecord($this->id,'id,uri,etag','contacts',false,'abook_id');
 	foreach($contacts as $contact) {
@@ -490,6 +497,8 @@ EOF
 		$dbh->table_name('carddav_addressbooks') .
 		' SET last_updated=' . $dbh->now() .' WHERE id=?',
 			$this->id);
+
+	self::$helper->release_lock($this->id);
 
 	$duration = time() - $duration;
 	self::$helper->debug("server refresh took $duration seconds");


### PR DESCRIPTION
This will prevent the plugin from trying to synchronise with the carddav server concurrently, which can happen if the user double-clicks the Addressbook tab, for example.

I have tried using a new database column as a lock indicator, but in my tests, the update never hit the disk fast enough for it to be picked up by the concurrent thread.

Caveats:
1. Sqlite3 backend not supported, but will fall-back graciously.
2. Pgsql lock mechanism was not tested.
3. If an exception occurs before the lock is released, it may have to be released manually! This must be fixed by improving exception handling generally in the plugin.
