### PR TITLE
add delete_all function

### DIFF
--- a/carddav_backend.php
+++ b/carddav_backend.php
@@ -2107,7 +2107,6 @@ EOF
     $this->delete($contact_ids);
 
     if ($with_groups != false) {
-      rcube::write_log('carddav', 'deleting groups');
       $res2 = $dbh->query('SELECT id FROM carddav_groups WHERE abook_id=?',$abook_id);
       while($row = $dbh->fetch_assoc($res2)) {
         $this->delete_group($row['id']);

--- a/carddav_backend.php
+++ b/carddav_backend.php
@@ -2095,6 +2095,26 @@ EOF
 	self::$helper->debug("delete old prefs: " . $rcmail->user->save_prefs($usettings));
 	}}}
 
+  public function delete_all($with_groups = false)
+  {{{
+    $dbh = rcmail::get_instance()->db;
+    $abook_id = $this->id;
+    $res1 = $dbh->query('SELECT id FROM carddav_contacts WHERE abook_id=?',$abook_id);
+    $contact_ids = array();
+    while($row = $dbh->fetch_assoc($res1)) {
+      $contact_ids[] = $row['id'];
+    }
+    $this->delete($contact_ids);
+
+    if ($with_groups != false) {
+      rcube::write_log('carddav', 'deleting groups');
+      $res2 = $dbh->query('SELECT id FROM carddav_groups WHERE abook_id=?',$abook_id);
+      while($row = $dbh->fetch_assoc($res2)) {
+        $this->delete_group($row['id']);
+      }
+    }
+  }}}
+
 	public static function initClass()
 	{{{
 	self::$helper = new carddav_common('BACKEND: ');


### PR DESCRIPTION
when choosing to import contacts into roundcube, the option "rcmimportreplace" can be toggled on. when on, program/steps/addressbook/import.inc calls:

 97         if ($replace) {
 98             $CONTACTS->delete_all($CONTACTS->groups && $with_groups < 2);
 99         }

currently, the function is not defined in carddav so contacts/groups are not cleaned from the user's carddav store before importing. after the patch, the rcmimportreplace function works as expected.