### PR TITLE
Fix multiple group members not being stored

### DIFF
--- a/carddav_backend.php
+++ b/carddav_backend.php
@@ -1877,7 +1877,7 @@ EOF
 			$contact = self::get_dbrecord($cid,'cuid');
 			if(!$contact) return false;
 
-			$vcf->{'X-ADDRESSBOOKSERVER-MEMBER'} = "urn:uuid:" . $contact['cuid'];
+			$vcf->add('X-ADDRESSBOOKSERVER-MEMBER', "urn:uuid:" . $contact['cuid']);
 		}
 
 		$vcfstr = $vcf->serialize();


### PR DESCRIPTION
Multiple group members were not being actually written to the vCard document. Only the last one was
being stored due to @X-ADDRESSBOOKSERVER-MEMBER@ being overwritten.

Related to #80 and #170 