### PR TITLE
Handle empty groups gracefully

### DIFF
--- a/carddav_backend.php
+++ b/carddav_backend.php
@@ -743,6 +743,10 @@ EOF
 				// record group members for deferred store
 				$this->users_to_add[$dbid] = array();
 				$members = $vcfobj->{'X-ADDRESSBOOKSERVER-MEMBER'};
+				if ($members === null) {
+				    $members = array();
+				}
+
 				self::$helper->debug("Group $dbid has " . count($members) . " members");
 				foreach($members as $mbr) {
 					$mbr = preg_split('/:/', $mbr);


### PR DESCRIPTION
Groups with no members produce a PHP warning:

`PHP Warning: Invalid argument supplied for foreach() in .../carddav_backend.php in line 747`
