### PR TITLE
Add a new global "sync_collection_workaround" preference.

### DIFF
--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -34,6 +34,17 @@
 // too old.
 $prefs['_GLOBAL']['suppress_version_warning'] = false;
 
+// Enable a workaround for broken sync-collection support in the
+// server. RFC 6578 specifies the "sync-collection" method for
+// synchronizing collections of things over WebDAV. It is more
+// efficient -- but also more complicated -- than simply retrieving
+// the whole collection again as necessary. As a result, some server
+// implementations are buggy. Specifically DAViCal and Radicale are
+// known to have problems. If changes (updates, deletions) from one
+// connection do not sync to another, you can try enabling this
+// workaround to revert to the inefficient-but-simple method.
+$prefs['_GLOBAL']['sync_collection_workaround'] = false;
+
 //// ** ADDRESSBOOK PRESETS
 
 // Each addressbook preset takes the following form:


### PR DESCRIPTION
Server support for sync-collection is still a bit iffy these days. At
least DAViCal and Radicale have bugs in their support that causes
synchronization to fail. In lieu of a way to detect whether or not
sync-collection works properly, the simplest thing to do is offer
users the ability to skip it.

This commit adds a new global "sync_collection_workaround"
preference. When enabled, the backend will use list_records_propfind()
instead of list_records_sync_collection(). It is off by default.

Github-Issue: 179