### PR TITLE
Replace substring occurences of username placeholders

### DIFF
--- a/carddav_common.php
+++ b/carddav_common.php
@@ -155,10 +155,9 @@ class carddav_common
 	$domain = $rcmail->user->get_username('domain');
 
 	// Substitute Placeholders
-	if($username == '%u')
-		$username = $_SESSION['username'];
-	if($username == '%l')
-		$username = $local;
+	$username = str_replace( '%u', $_SESSION['username'], $username);
+	$username = str_replace( '%l', $local, $username);
+	$username = str_replace( '%d', $domain, $username);
 	if($password == '%p')
 		$password = $rcmail->decrypt($_SESSION['password']);
 	$baseurl = str_replace("%u", $username, $carddav['url']);


### PR DESCRIPTION
Instead of only replacing '%u' and '%l' when they are a literal
match, so a substring replacment of them. This is especially
useful when the Roundcube login doesn't use domain part, but
CardDAV server requires domain part. With this change, it allows
preset configurations to set username to '%u@example.com'.

The documentation offers '%d' as another valid placeholder, but
it wasn't actually being replaced. Fixes this ommission as above.