### PR TITLE
Properly quote array keys in preset creation

### DIFF
--- a/carddav.php
+++ b/carddav.php
@@ -240,11 +240,11 @@ class carddav extends rcube_plugin
 
 			if(is_array($srvs)) {
 			foreach($srvs as $srv){
-				if($srv[name]) {
-					if($preset[carddav_name_only])
-						$preset['name'] = $srv[name];
+				if($srv['name']) {
+					if($preset['carddav_name_only'])
+						$preset['name'] = $srv['name'];
 					else
-						$preset['name'] = "$abname (" . $srv[name] . ')';
+						$preset['name'] = "$abname (" . $srv['name'] . ')';
 				} else {
 					$preset['name'] = $abname;
 				}


### PR DESCRIPTION
Prevents following warnings and possible errors in future versions.

```
PHP Warning:  Use of undefined constant name - assumed 'name' (this will throw an Error in a future version of PHP) in /usr/share/roundcube/plugins/carddav/carddav.php on line 243
PHP Warning:  Use of undefined constant carddav_name_only - assumed 'carddav_name_only' (this will throw an Error in a future version of PHP) in /usr/share/roundcube/plugins/carddav/carddav.php on line 244
PHP Warning:  Use of undefined constant name - assumed 'name' (this will throw an Error in a future version of PHP) in /usr/share/roundcube/plugins/carddav/carddav.php on line 245
```