### PR TITLE
preg_match fix

### DIFF
--- a/carddav_discovery.php
+++ b/carddav_discovery.php
@@ -254,7 +254,7 @@ EOF
 			if($dnsresult['host'] != $dnssrv) continue;
 
 			foreach($dnsresult['entries'] as $ent) {
-				if (preg_match('^path=(.+)', $ent, $match))
+				if (preg_match('/^path=(.+)/', $ent, $match))
 					$paths[] = $match[1];
 			}
 		}


### PR DESCRIPTION
fixed php warning
PHP Warning:  preg_match(): No ending delimiter '^' found in /srv/web/mail/htdocs/roundcubemail/plugins/carddav/carddav_discovery.php on line 258