### PR TITLE
Fix issue #109

### DIFF
--- a/carddav_common.php
+++ b/carddav_common.php
@@ -182,6 +182,12 @@ class carddav_common
 				$httpful->addHeader("User-Agent", "RCM CardDAV plugin/3.0.3");
 				$httpful->uri($url);
 				$httpful->method($http_opts['method']);
+
+                // Prevent 400 bad request on REPORT calls for Apple CCS if possible by setting a content body
+                if (array_key_exists('content',$http_opts) && strlen($http_opts['content'])>0 && $http_opts['method'] != "GET"){
+                    $httpful->body($http_opts['content']);
+                }
+
 				$error = $httpful->send();
 
 				$httpful = \Httpful\Request::init();


### PR DESCRIPTION
The issue with figuring out the auth method during REPORT calls on Apple CCS
was that the Apple server issues 400 Bad Request when REPORT calls have
no request body *before* it wants to issue a 401 with a WWW-Authenticate
challenge header. To prevent this, simply set the request body before
doing the call, as in this context, it should exist.